### PR TITLE
Adjust typography styles on H2s for emphasis

### DIFF
--- a/main.css
+++ b/main.css
@@ -41,10 +41,21 @@ pfe-band {
 pfe-band.header h1 {
   margin: 0;
 }
-
-pfe-band h2 {
+pfe-band h2[id] {
   font-size: 1.5rem;
   line-height: 1.9375rem;
+  font-weight: bold;
+  margin-top: 2em;
+}
+pfe-band h3[id] {
+    font-size: 1.3rem;
+    font-weight: bold;
+}
+@media (min-width: 1200px) {
+  pfe-band h2[id] {
+    font-size: 2rem;
+    line-height: 2.3125rem;
+  }
 }
 
 pfe-band h1+p,
@@ -377,12 +388,6 @@ main.basic {
   }
 }
 
-@media (min-width: 1200px) {
-  pfe-band h2 {
-    font-size: 1.75rem;
-    line-height: 2.3125rem;
-  }
-}
 
 /******* THEME 2:  purple / yellow ******/
 #themeable-section.theme-2 {


### PR DESCRIPTION
It's hard to scan the sections of the page since they all blend together.
Added specificity so as to not change the h2 styles in the examples.

Before:

![image](https://user-images.githubusercontent.com/456863/95513884-0d1b6200-0989-11eb-9c61-99a3f66ba934.png)


---------------

After:

![image](https://user-images.githubusercontent.com/456863/95513925-17d5f700-0989-11eb-9939-f09121361bf5.png)
